### PR TITLE
Merge v1.0.5 develop into master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     # Setup docker
     docker:
-      - image: usdotfhwastol/carma-base:2.8.1
+      - image: usdotfhwastol/carma-base:2.8.2
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,12 @@ jobs:
           name: Build Driver
           command: |
             source ${INIT_ENV}
-            build-wrapper-linux-x86-64 --out-dir /opt/carma/bw-output catkin_make install -j 2
+            build-wrapper-linux-x86-64 --out-dir /opt/carma/bw-output bash make_with_coverage.bash -m -e /opt/carma/ -o ./coverage_reports/gcov
       - run:
           name: Run C++ Tests
           command: |
-            source /opt/carma/devel/setup.bash
-            catkin_make run_tests
+            source ${INIT_ENV}
+            bash make_with_coverage.bash -t -e /opt/carma/ -o ./coverage_reports/gcov
       # Run SonarCloud analysis
       # PR Branchs and number extracted from Circle variables and github api
       # Circle CI seems to make a change to the base branch, so we must fetch --force to ensure correct git file change stats
@@ -75,6 +75,12 @@ jobs:
           name: Run Sonar Scanner
           command: |
             source ${INIT_ENV}
+            if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
+              echo "Non-PR Build Detected. Running analysis on ${CIRCLE_BRANCH}"
+              cd src/CARMADriverUtils
+              sonar-scanner -Dproject.settings=.sonarqube/sonar-scanner.properties -Dsonar.login=${SONAR_SCANNER_TOKEN} 
+              exit 0;
+            fi
             echo "PR branch ${CIRCLE_BRANCH}"
             echo "Repo name ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             echo "URL ${CIRCLE_PULL_REQUEST}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,45 @@
 version: 2
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+# 
+
+# Configuration file for Circle CI 
+# CI will report failure if any executed command returns and error status
+# Operations performed are as follows
+# Build source code
+# Run unit tests for C++ and Java
+# Run static code analyzer for SourceCloud
+# Upload test results
+# Every run command should start with source ${INIT_ENV} to ensure all default dependancies are available
+
 jobs:
   build:
-    # Setup docker
+    # Pull docker image from docker hub
+    # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/carma-base:2.8.2
+      - image: usdotfhwastol/carma-base-ci:2.8.4
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build
+          INIT_ENV: /home/carma/.base-image/init-env.sh
     working_directory: "/opt/carma/"
     # Execution steps
     steps:
       - run:
           name: Create src folder
           command: |
+            source ${INIT_ENV}
             mkdir src
             cd src
             mkdir CARMADriverUtils
@@ -22,16 +49,41 @@ jobs:
       - run: 
           name: Pull CARMAMsgs
           command: |
-            source /opt/ros/kinetic/setup.bash
+            source ${INIT_ENV}
             git clone -b develop --depth 1 git@github.com:usdot-fhwa-stol/CARMAMsgs.git src/CARMAMsgs
       - run:
           name: Build Driver
           command: |
-            source /opt/ros/kinetic/setup.bash
-            catkin_make install
+            source ${INIT_ENV}
+            build-wrapper-linux-x86-64 --out-dir /opt/carma/bw-output catkin_make install -j 2
       - run:
           name: Run C++ Tests
           command: |
-            source /opt/ros/kinetic/setup.bash
             source /opt/carma/devel/setup.bash
             catkin_make run_tests
+      # Run SonarCloud analysis
+      # PR Branchs and number extracted from Circle variables and github api
+      # Circle CI seems to make a change to the base branch, so we must fetch --force to ensure correct git file change stats
+      # SONAR_SCANNER_TOKEN MUST be secured as an environment variable in Circle CI NOT in this file. 
+      # The following sonar settings MUST be set in SonarCloud UI NOT in this file
+      # sonar.pullrequest.provider
+      # sonar.pullrequest.github.endpoint
+      # sonar.pullrequest.github.token.secured
+      # sonar.pullrequest.github.repository
+      # Use -X on sonar-scanner to enable debug output
+      - run:
+          name: Run Sonar Scanner
+          command: |
+            source ${INIT_ENV}
+            echo "PR branch ${CIRCLE_BRANCH}"
+            echo "Repo name ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            echo "URL ${CIRCLE_PULL_REQUEST}"
+            export PR_NUM=`echo ${CIRCLE_PULL_REQUEST} | cut -d'/' -f7`
+            echo "PR number ${PR_NUM}"
+            export BASE_BRANCH_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUM}"
+            export TARGET_BRANCH=$(curl "$BASE_BRANCH_URL" | jq '.base.ref' | tr -d '"') 
+            echo "Target Branch = ${TARGET_BRANCH}"
+            cd src/CARMADriverUtils
+            git fetch --force origin ${TARGET_BRANCH}:${TARGET_BRANCH}
+            sonar-scanner -Dproject.settings=.sonarqube/sonar-scanner.properties -Dsonar.login=${SONAR_SCANNER_TOKEN} -Dsonar.pullrequest.base=${TARGET_BRANCH} -Dsonar.pullrequest.branch=${CIRCLE_BRANCH} -Dsonar.pullrequest.key=${PR_NUM}
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    # Setup docker
+    docker:
+      - image: usdotfhwastol/carma-base:2.8.1
+        user: carma
+        environment:
+          TERM: xterm # use xterm to get full display output from build
+    working_directory: "/opt/carma/"
+    # Execution steps
+    steps:
+      - run:
+          name: Create src folder
+          command: |
+            mkdir src
+            cd src
+            mkdir CARMADriverUtils
+            mkdir CARMAMsgs
+      - checkout:
+          path: src/CARMADriverUtils
+      - run: 
+          name: Pull CARMAMsgs
+          command: |
+            source /opt/ros/kinetic/setup.bash
+            git clone -b develop --depth 1 git@github.com:usdot-fhwa-stol/CARMAMsgs.git src/CARMAMsgs
+      - run:
+          name: Build Driver
+          command: |
+            source /opt/ros/kinetic/setup.bash
+            catkin_make install
+      - run:
+          name: Run C++ Tests
+          command: |
+            source /opt/ros/kinetic/setup.bash
+            source /opt/carma/devel/setup.bash
+            catkin_make run_tests

--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -34,6 +34,6 @@ socketcan_bridge.sonar.projectBaseDir=/opt/carma/src/CARMADriverUtils/socketcan_
 socketcan_interface.sonar.projectBaseDir=/opt/carma/src/CARMADriverUtils/socketcan_interface
 
 # Tests
-# Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
+sonar.cfamily.gcov.reportsPath=/opt/carma/coverage_reports/gcov
 socketcan_bridge.sonar.tests=test
 socketcan_interface.sonar.tests=test

--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -1,0 +1,39 @@
+#  Copyright (C) 2018-2019 LEIDOS.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# Configuration file for Sonar Scanner used for CI
+
+sonar.projectKey=usdot-fhwa-stol_CARMADriverUtils
+sonar.organization=usdot-fhwa-stol
+sonar.cfamily.build-wrapper-output=/opt/carma/bw-output
+sonar.host.url=https://sonarcloud.io
+sonar.sources=src/, include/
+# Disable SCM sensor as it is unused but generates warning
+sonar.scm.disabled=false
+sonar.scm.enabled=true
+sonar.scm.provider=git
+
+# C++ Modules
+sonar.modules= cav_driver_utils, \
+  socketcan_bridge, \
+  socketcan_interface
+
+cav_driver_utils.sonar.projectBaseDir=/opt/carma/src/CARMADriverUtils/cav_driver_utils
+socketcan_bridge.sonar.projectBaseDir=/opt/carma/src/CARMADriverUtils/socketcan_bridge
+socketcan_interface.sonar.projectBaseDir=/opt/carma/src/CARMADriverUtils/socketcan_interface
+
+# Tests
+# Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
+socketcan_bridge.sonar.tests=test
+socketcan_interface.sonar.tests=test

--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -19,7 +19,7 @@ sonar.organization=usdot-fhwa-stol
 sonar.cfamily.build-wrapper-output=/opt/carma/bw-output
 sonar.host.url=https://sonarcloud.io
 sonar.sources=src/, include/
-# Disable SCM sensor as it is unused but generates warning
+# Set Git as SCM sensor
 sonar.scm.disabled=false
 sonar.scm.enabled=true
 sonar.scm.provider=git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CARMACadillacSrx2013ControllerDriver
+# CARMADriverUtils
 CARMADriverUtils contains packages relevent to or useful for developing device drivers for usage with the CARMAPlatform  
 
 This package is required to build most of the CARMAPlatform device drivers

--- a/cav_driver_utils/CMakeLists.txt
+++ b/cav_driver_utils/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(Boost REQUIRED system)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES driver_application cav_socketcan_interface ros_socketcan_interface
+  LIBRARIES driver_application cav_socketcan_interface ros_socketcan_interface driver_wrapper
   CATKIN_DEPENDS bondcpp cav_msgs cav_srvs roscpp std_msgs
 #  DEPENDS system_lib
 )
@@ -43,35 +43,36 @@ include_directories(
 ## Declare a C++ library
 add_library(driver_application
     src/driver_application/driver_application.cpp
-    include/driver_application/driver_application.h
-)
+    include/driver_application/driver_application.h)
 
 add_dependencies(driver_application ${catkin_EXPORTED_TARGETS})
 
 # Specify libraries to link a library or executable target against
- target_link_libraries(driver_application
-   ${catkin_LIBRARIES}
- )
+target_link_libraries(driver_application ${catkin_LIBRARIES})
 
 add_library(cav_socketcan_interface
         src/socketcan_interface/socketcan_interface.cpp
-        include/cav_driver_utils/can/socketcan_interface/socketcan_interface.h
-        )
+        include/cav_driver_utils/can/socketcan_interface/socketcan_interface.h)
 
 add_dependencies(cav_socketcan_interface ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(cav_socketcan_interface
-        ${Boost_LIBRARIES})
+target_link_libraries(cav_socketcan_interface ${Boost_LIBRARIES})
 
 add_library(ros_socketcan_interface
         src/ros_socketcan_bridge/ros_socketcan_bridge.cpp
-        include/cav_driver_utils/can/ros_socketcan_bridge/ros_socketcan_bridge.h
-        )
+        include/cav_driver_utils/can/ros_socketcan_bridge/ros_socketcan_bridge.h)
 
 add_dependencies(ros_socketcan_interface ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(ros_socketcan_interface
-        ${Boost_LIBRARIES})
+target_link_libraries(ros_socketcan_interface ${Boost_LIBRARIES})
+
+add_library(driver_wrapper
+    src/driver_wrapper/driver_wrapper.cpp
+    include/driver_wrapper/driver_wrapper.h)
+
+add_dependencies(driver_wrapper ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(driver_wrapper ${catkin_LIBRARIES})
 
 #############
 ## Install ##
@@ -88,7 +89,7 @@ target_link_libraries(ros_socketcan_interface
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS driver_application cav_socketcan_interface ros_socketcan_interface
+install(TARGETS driver_application driver_wrapper cav_socketcan_interface ros_socketcan_interface
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 # RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -96,17 +97,22 @@ install(TARGETS driver_application cav_socketcan_interface ros_socketcan_interfa
 
 ## Mark cpp header files for installation
 install(DIRECTORY include/driver_application/
-    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-    FILES_MATCHING PATTERN "*.h"
-    PATTERN ".svn" EXCLUDE
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h"
+        PATTERN ".svn" EXCLUDE
 )
 
 install(DIRECTORY include/cav_driver_utils/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
         FILES_MATCHING PATTERN "*.h"
         PATTERN ".svn" EXCLUDE
-        )
+)
 
+install(DIRECTORY include/driver_wrapper/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h"
+        PATTERN ".svn" EXCLUDE
+)
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 # install(FILES

--- a/cav_driver_utils/include/cav_driver_utils/active_robotic_status_provider.h
+++ b/cav_driver_utils/include/cav_driver_utils/active_robotic_status_provider.h
@@ -52,7 +52,7 @@ class ActiveRoboticStatusProvider
     bool active_, enabled_;
 public:
 
-    ActiveRoboticStatusProvider() : pnh_("~control"), active_(false), enabled_(false)
+    ActiveRoboticStatusProvider() : pnh_("/control"), active_(false), enabled_(false)
     {
         pub_ = pnh_.advertise<cav_msgs::RobotEnabled>("robot_status", 1);
         api_.push_back(pub_.getTopic());

--- a/cav_driver_utils/include/cav_driver_utils/enable_robotic_service.h
+++ b/cav_driver_utils/include/cav_driver_utils/enable_robotic_service.h
@@ -72,7 +72,7 @@ public:
      */
     boost::signals2::signal<void (bool)> onEnabledChanged;
 
-    EnableRoboticService() : pnh_("~control")
+    EnableRoboticService() : pnh_("/control")
     {
         pnh_.param<bool>("enabled_at_start", robotic_enabled_, false);
         srv_ = pnh_.advertiseService("enable_robotic", &EnableRoboticService::_cb, this);

--- a/cav_driver_utils/include/cav_driver_utils/longitudinal_effort_controller.h
+++ b/cav_driver_utils/include/cav_driver_utils/longitudinal_effort_controller.h
@@ -74,7 +74,7 @@ public:
     typedef LongitudinalEffortControllerCommand Command;
     Command command;
 
-    LongitudinalEffortController() : pnh_("~control")
+    LongitudinalEffortController() : pnh_("/control")
     {
         sub_ =  pnh_.subscribe<std_msgs::Float32>("cmd_longitudinal_effort",1,&LongitudinalEffortController::_cb, this);
         api_.push_back(sub_.getTopic());

--- a/cav_driver_utils/include/cav_driver_utils/longitudinal_speed_controller.h
+++ b/cav_driver_utils/include/cav_driver_utils/longitudinal_speed_controller.h
@@ -75,7 +75,7 @@ public:
     typedef LongitudinalSpeedControllerCommand Command;
     Command command;
 
-    LongitudinalSpeedController() : pnh_("~control")
+    LongitudinalSpeedController() : pnh_("/control")
     {
         sub_ =  pnh_.subscribe<cav_msgs::SpeedAccel>("cmd_speed",1,&LongitudinalSpeedController::_cb, this);
         api_.push_back(sub_.getTopic());

--- a/cav_driver_utils/include/driver_wrapper/driver_wrapper.h
+++ b/cav_driver_utils/include/driver_wrapper/driver_wrapper.h
@@ -54,6 +54,7 @@ protected:
 
     std::shared_ptr<ros::NodeHandle> nh_, private_nh_;
     cav_msgs::DriverStatus status_;
+    int spin_rate_;
 
 private:
 
@@ -90,7 +91,6 @@ private:
     // Initialize necessary publishers and subscribers
     ros::Publisher  driver_status_pub_;
     ros::Subscriber system_alert_sub_;
-    int spin_rate_;
     bool shutdown_;
 
 };

--- a/cav_driver_utils/include/driver_wrapper/driver_wrapper.h
+++ b/cav_driver_utils/include/driver_wrapper/driver_wrapper.h
@@ -1,0 +1,98 @@
+#pragma once
+
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <ros/ros.h>
+#include <cav_msgs/DriverStatus.h>
+#include <cav_msgs/SystemAlert.h>
+
+namespace cav
+{
+
+class DriverWrapper
+{
+
+public:
+
+    /**
+     * @brief DriverWrapper Constructor
+     * @param argc Command line argument count
+     * @param argv Array of command line arguments
+     * @param name Node name
+     */
+    DriverWrapper(int argc, char** argv, std::string name = "driver_wrapper") : status_(), spin_rate_(10), shutdown_(false)
+    {
+        ros::init(argc, argv, name);
+    }
+
+    /**
+     * @brief ~DriverWrapper Destructor
+     */
+    virtual ~DriverWrapper(){}
+
+    /**
+     * @brief run Starts the driver wrapper
+     * @return 0 on exit with no errors
+     */
+    virtual int run() final;
+
+protected:
+
+    std::shared_ptr<ros::NodeHandle> nh_, private_nh_;
+    cav_msgs::DriverStatus status_;
+
+private:
+
+    /**
+     * @brief Initialize the node prior to beginning ROS loop.
+     */
+    virtual void initialize() = 0;
+
+    /**
+     * @brief Called prior to spinOnce()
+     */
+    virtual void pre_spin() = 0;
+
+    /**
+     * @brief Called after spinOnce()
+     */
+    virtual void post_spin() = 0;
+
+    /**
+     * @brief Prepare for node shutdown
+     */
+    virtual void shutdown() = 0;
+
+    /**
+     * @brief Called every second to publish the status message
+     */
+    void status_publish_timer(const ros::TimerEvent &) const;
+
+    /**
+     * @brief Callback on system alert topic
+     */
+    void system_alert_cb(const cav_msgs::SystemAlertConstPtr& msg);
+
+    // Initialize necessary publishers and subscribers
+    ros::Publisher  driver_status_pub_;
+    ros::Subscriber system_alert_sub_;
+    int spin_rate_;
+    bool shutdown_;
+
+};
+
+};

--- a/cav_driver_utils/src/driver_wrapper/driver_wrapper.cpp
+++ b/cav_driver_utils/src/driver_wrapper/driver_wrapper.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <driver_wrapper/driver_wrapper.h>
+
+namespace cav {
+
+int DriverWrapper::run()
+{
+    nh_.reset(new ros::NodeHandle);
+    private_nh_.reset(new ros::NodeHandle("~"));
+
+    //Setup initial status
+    status_.name = ros::this_node::getName();
+    status_.status = cav_msgs::DriverStatus::OFF;
+
+    //Initialize pubs and subs
+    driver_status_pub_ = nh_->advertise<cav_msgs::DriverStatus>("driver_discovery", 1);
+    system_alert_sub_ = nh_->subscribe("system_alert", 10, &DriverWrapper::system_alert_cb, this);
+    ros::Timer timer = private_nh_->createTimer(ros::Duration(1), &DriverWrapper::status_publish_timer, this);
+
+    ROS_INFO_STREAM("Driver Initializing");
+
+    initialize();
+    ros::Rate r(spin_rate_);
+    while(ros::ok() && !shutdown_)
+    {
+        pre_spin();
+        ros::spinOnce();
+        post_spin();
+        r.sleep();
+    }
+
+    ROS_INFO_STREAM("Driver Shutting Down");
+    shutdown();
+    ros::shutdown();
+}
+
+void DriverWrapper::status_publish_timer(const ros::TimerEvent &) const
+{
+    driver_status_pub_.publish(status_);
+}
+
+void DriverWrapper::system_alert_cb(const cav_msgs::SystemAlertConstPtr &msg)
+{
+    u_char t = msg->type;
+    if(t == cav_msgs::SystemAlert::FATAL || t == cav_msgs::SystemAlert::SHUTDOWN)
+    {
+        shutdown_ = true;
+    }
+}
+
+}


### PR DESCRIPTION
Master will need to be tagged with Version_1.0.5 after merging.
Note that this repo has three independently versioned packages in it, but two of them are third party items that we have not modified and anticipate no future modifications of.  Therefore, we are using the version ID from the cav_driver_utils package as the repo version for the time being.